### PR TITLE
Fixes typo in iDRACConfig.py _scp_import_redfish

### DIFF
--- a/omdrivers/lifecycle/iDRAC/iDRACConfig.py
+++ b/omdrivers/lifecycle/iDRAC/iDRACConfig.py
@@ -1316,7 +1316,7 @@ iDRACWsManCmds = {
                 {'@Name': 'Name', '#text': 'SoftwareUpdate'},
                 {'@Name': 'SystemName', '#text': 'IDRAC:ID'}
             ]
-        },
+        },-
         "Args": {
             "ipaddress": str,
             "share_type": int,
@@ -2161,7 +2161,7 @@ iDRACWsManCmds = {
             ('ShareParameters/ShareName', "share", "remote_share_name", type("\\test"), None),
             ('ShareParameters/ShareType', "share", "remote_share_type_redfish", Share.ShareTypeRedfish, None),
             ('ShareParameters/FileName', "share", "remote_file_name", type("filename"), None),
-            ('ShareParameters/UserName', "creds", "username", type("user"), None),
+            ('ShareParameters/Username', "creds", "username", type("user"), None),
             ('ShareParameters/Password', "creds", "password", type("password"), None),
             ('ShareParameters/Target', "target", None, type(""), None),
             ("ShutdownType", "shutdown_type", None, ShutdownTypeRedfishEnum, None),

--- a/omdrivers/lifecycle/iDRAC/iDRACConfig.py
+++ b/omdrivers/lifecycle/iDRAC/iDRACConfig.py
@@ -1316,7 +1316,7 @@ iDRACWsManCmds = {
                 {'@Name': 'Name', '#text': 'SoftwareUpdate'},
                 {'@Name': 'SystemName', '#text': 'IDRAC:ID'}
             ]
-        },-
+        },
         "Args": {
             "ipaddress": str,
             "share_type": int,


### PR DESCRIPTION
There was a typo which broke uploading to and downloading from network shares. 
This prevents OMAM from working correctly. 
[https://github.com/dell/dellemc-openmanage-ansible-modules/issues/45](https://github.com/dell/dellemc-openmanage-ansible-modules/issues/45)

System: R7415
iDRAC version: 3.30.30.30
BIOS: 1.7.6