### PR TITLE
Added a sleep when polling OSD Jobs

### DIFF
--- a/omdrivers/lifecycle/iDRAC/iDRACJobs.py
+++ b/omdrivers/lifecycle/iDRAC/iDRACJobs.py
@@ -147,6 +147,7 @@ class iDRACJobs(iBaseJobApi):
         jobret = {"Status": TypeHelper.resolve(JobStatusEnum.InProgress)}
         if jobid.startswith('DCIM_OSD'):
             # Poll for OSD Concrete Job
+            time.sleep( 10 )
             jobs = self._get_osd_job_details()
         else:
             jobs = self.get_job_details(jobid)

--- a/omdrivers/lifecycle/iDRAC/iDRACJobs.py
+++ b/omdrivers/lifecycle/iDRAC/iDRACJobs.py
@@ -147,7 +147,6 @@ class iDRACJobs(iBaseJobApi):
         jobret = {"Status": TypeHelper.resolve(JobStatusEnum.InProgress)}
         if jobid.startswith('DCIM_OSD'):
             # Poll for OSD Concrete Job
-            time.sleep( 10 )
             jobs = self._get_osd_job_details()
         else:
             jobs = self.get_job_details(jobid)
@@ -239,6 +238,7 @@ class iDRACJobs(iBaseJobApi):
         job_ret = False
         wait_till = time.time() + wait_for
         while True:
+            time.sleep( 30 )
             status = {}
             if self.entity.use_redfish:
                 status = self.get_job_status_redfish(jobid)
@@ -272,7 +272,6 @@ class iDRACJobs(iBaseJobApi):
                     break
                 else:
                     logger.debug(self.entity.ipaddr+" : "+jobid+ ": status: "+str(status))
-            time.sleep(5)
             if time.time() > wait_till:
                 ret_json['Status'] = 'Failed'
                 ret_json['Message'] = 'Job wait did not return for {0} seconds'.format(wait_for)


### PR DESCRIPTION
Added a sleep to work around issue:
https://github.com/dell/dellemc-openmanage-ansible-modules/issues/32

This appears to be a timing issue.  Adding a 10 second sleep allows the ansible module to reliably get the Job status return without failing.

I am not sure this is best place for this sleep but does seem like a simple work around to allow it to function correctly until this could be properly fixed.