### PR TITLE
Add wheel to requirements

### DIFF
--- a/requirements-python2x.txt
+++ b/requirements-python2x.txt
@@ -5,3 +5,4 @@ requests>=2.12.3
 PyYAML>=3.12
 future>=0.16.0
 pysnmp_mibs>=0
+wheel

--- a/requirements-python3x.txt
+++ b/requirements-python3x.txt
@@ -3,3 +3,4 @@ requests>=2.12.3
 PyYAML>=3.12
 future>=0.16.0
 pysnmp_mibs>=0
+wheel


### PR DESCRIPTION
The build will fail without wheel. Fairly easy for a python person to fix, but less obvious to the uninitiated. Adding it to the requirements fixes the problem.