### PR TITLE
add EventFilters to omdrivers iDRACEnums

### DIFF
--- a/omdrivers/enums/iDRAC/iDRACEnums.py
+++ b/omdrivers/enums/iDRAC/iDRACEnums.py
@@ -149,6 +149,9 @@ SCPTargetEnum = EnumWrapper("SCPTargetEnum", {
     'BIOS': 'BIOS',
     'NIC': 'NIC',
     'RAID': 'RAID',
+    'EVENTFILTERS': 'EVENTFILTERS',
+    'SUPPORTASSIST': 'SUPPORTASSIST',
+    'LIFECYCLECONTROLLER': 'LIFECYCLECONTROLLER',
 }).enum_type
 
 RAIDLevelsEnum = EnumWrapper("RLE", {


### PR DESCRIPTION
I also added the other "missing" ones, SupportAssist and LifecycleController

Refs dell/dellemc-openmanage-ansible-modules#342