### PR TITLE
Bugfix for issue #33 - SNIMissingWarning

### DIFF
--- a/omsdk/http/sdkhttpep.py
+++ b/omsdk/http/sdkhttpep.py
@@ -25,7 +25,7 @@ import requests.adapters
 import requests.exceptions
 import requests.packages.urllib3
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
-from requests.packages.urllib3.exceptions import SNIMissingWarning
+#from requests.packages.urllib3.exceptions import SNIMissingWarning
 from requests.packages.urllib3.exceptions import InsecurePlatformWarning
 from omsdk.sdkcenum import EnumWrapper, TypeHelper
 import logging


### PR DESCRIPTION
Removed import of SNIMissingWarning from urllib3 due to the function being removed in versions > 1.26.11