### PR TITLE
fix(ECS02C-1187): Honor verify_ssl in redfish_operation

### DIFF
--- a/omsdk/http/sdkwsmanbase.py
+++ b/omsdk/http/sdkwsmanbase.py
@@ -324,7 +324,7 @@ class WsManProtocolBase(ProtocolBase):
 
         url = self._get_base_url(ipaddr=self.proto.ipaddr, resouce_path=rpath, port=self.proto.pOptions.port)
         auth = HTTPBasicAuth(self.proto.creds.username, self.proto.creds.password)
-        cert_verify = False
+        cert_verify = self.proto.pOptions.verify_ssl
         headers = {'content-type': 'application/json'}
         kwargs = self._pack_rest_method_args(auth=auth, verify=cert_verify, data=redfish_payload, headers=headers)
         retval = {}


### PR DESCRIPTION
## Summary

`WsManProtocolBase.redfish_operation()` in `omsdk/http/sdkwsmanbase.py` hardcoded `cert_verify = False` on line 327, causing TLS certificate validation to be silently disabled for all Redfish operations regardless of the `verify_ssl` option passed via `WsManOptions`.

## Root Cause

The WS-Man/SOAP code path (`HttpEndPoint.connect()`) correctly uses `self.pOptions.verify_ssl`, but the Redfish code path in `redfish_operation()` bypassed this with a hardcoded `False`.

## Fix

Single-line change:
```diff
- cert_verify = False
+ cert_verify = self.proto.pOptions.verify_ssl
```

## Testing

- 3 new unit tests for verify_ssl forwarding (CA path, False, True)
- 66 existing openmanage idrac_bios tests pass
- 17 existing openmanage idrac_lc_attributes tests pass

## Jira

ECS02C-1187